### PR TITLE
Add 'conduct' to the import statement from utils.js

### DIFF
--- a/qmkbot.js
+++ b/qmkbot.js
@@ -8,7 +8,7 @@ require('dotenv').config();
 const token = process.env.TOKEN;
 
 // Import utils.js
-const {prefix, baseurl, msg, docsSwitch, authroles, parse, bare, firmware, toolbox, plainhelp, disclaimer, ohshitgit} = require("./utils.js");
+const {prefix, baseurl, msg, docsSwitch, authroles, parse, bare, firmware, toolbox, plainhelp, disclaimer, ohshitgit, conduct} = require("./utils.js");
 let cooldown = require("./utils.js").cooldown;
 
 bot.on('ready', () => {


### PR DESCRIPTION
"!conduct" was breaking the bot because it wasn't actually being imported into qmkbot.js from utils.js.  This PR will fix that for now, but a future update should address this by wrapping with a try/except to address this breakage going forward.