### PR TITLE
Fix command/democratize

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "discord-message-handler": "^2.0.1",
     "discord.io": "^2.5.3",
-    "discord.js": "^11.4.2",
+    "discord.js": "^11.6.4",
     "dotenv": "^8.2.0",
     "node-gyp": "^6.1.0"
   },

--- a/qmkbot.js
+++ b/qmkbot.js
@@ -44,12 +44,22 @@ bot.on('message', message => {
           return;
         };
 
+	// commented out -- doc commands are being opened up to all members
+	/*
         if ((member.roles.some(r=>authroles.includes(r.name))) && !cooldown.includes(doc)) {
           channel.send(bare(`${baseurl}${doc}`));
           cooldown.push(doc);
         } else {
           author.send(`${baseurl}${doc}`);
         }
+	*/
+
+	// enforce 30 second cooldown on docs sent to channel
+	if (!cooldown.includes(doc)) {
+	  channel.send(bare(`${baseurl}${doc}`));
+	  cooldown.push(doc);
+	}
+
       }
     });
 

--- a/qmkbot.js
+++ b/qmkbot.js
@@ -8,7 +8,7 @@ require('dotenv').config();
 const token = process.env.TOKEN;
 
 // Import utils.js
-const {prefix, baseurl, msg, docsSwitch, authroles, parse, bare, firmware, toolbox, plainhelp, disclaimer, ohshitgit, coc} = require("./utils.js");
+const {prefix, baseurl, msg, docsSwitch, authroles, parse, bare, firmware, toolbox, plainhelp, disclaimer, ohshitgit, git, xkcd, coc} = require("./utils.js");
 let cooldown = require("./utils.js").cooldown;
 
 bot.on('ready', () => {
@@ -82,11 +82,16 @@ bot.on('message', message => {
         author.send(':potato:');
         break;
 
-      case 'ohshit': // PM a link to https://ohshitgit.com/
-        author.send(ohshitgit);
+      case 'ohshit': // send channel a link to https://ohshitgit.com/
+        channel.send(bare(ohshitgit));
         break;
 
-      case 'conduct': // PM a link to https://qmk.fm/coc/
+      case 'git': // send channel a link to QMK git best practices and xkcd #1597
+        channel.send(xkcd);
+        channel.send(bare(git));
+        break;
+
+      case 'conduct': // send channel a link to https://qmk.fm/coc/
         channel.send(coc);
         break;
 

--- a/readme.md
+++ b/readme.md
@@ -7,13 +7,11 @@ Bot Maintainer: [George Koenig (ridingqwerty)](https://github.com/ridingqwerty/)
 
 Usage:
 
-This bot is mostly for the benefit of the QMK Collaborators to be able to quickly link to documentation for something a QMK neophyte might need to be educated about.
+This bot is for the benefit of the QMK community to be able to quickly link to documentation in the QMK Discord server for something a newcomer might need to be educated about.
 
 Typing `!help` into any channel in the QMK Discord will cause the bot to PM a list of usable commands.
 
-A Collaborator typing any of these commands will post a publicly viewable link into the channel it was called in.
-
-Other users doing so will receive a PM of the documentation -- this is to prevent cluttering the help channels with embedded links.
+A community member typing any of these commands will post a publicly viewable link into the channel it was called in.
 
 The bot also responds to PMs directly, so users can interact with it privately if they would like.
 

--- a/utils.js
+++ b/utils.js
@@ -75,7 +75,6 @@ module.exports = {
     "flashing-bootloadhid": "flashing_bootloadhid",
     "ide-eclipse": "other_eclipse",
     "ide-vscode": "other_vscode",
-    "git": "newbs_git_best_practices",
     "hand-wire": "hand_wire",
     "isp-flashing": "isp_flashing_guide",
     "keycodes": "keycodes",
@@ -151,6 +150,8 @@ module.exports = {
   toolbox: 'https://github.com/qmk/qmk_toolbox/',
   disclaimer: "If you don't see an embed, try `!plain`",
   ohshitgit: 'https://ohshitgit.com/',
+  git: 'https://docs.qmk.fm/#/newbs_git_best_practices/',
+  xkcd: 'https://xkcd.com/1597/',
   coc: 'https://qmk.fm/coc/',
 
   cooldown: [],


### PR DESCRIPTION
-Opened up "!commands" to the general public.  The use of `<>` tags to minimize embeds make the danger of spamming out help channels negligible.  Commands are still subject to 30 second cooldown and "!help" still PMs the list of commands to all users.

-Made "!git" a little more fun.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
<!--- Mention 'Fixed #<issue_number>' (eg 'Fixed #1234') to link to fixed issues. -->
