### PR TITLE
Fix grammar disagreement between command and help

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -34,7 +34,7 @@ const helpmessage =  [
   },
   {
     name: "**Other Information**",
-    value: "mcus, contributing, translating, config-options, understanding-keyboards, understand-matrix, understanding-qmk, conduct"
+    value: "mcus, contributing, translating, config-options, understanding-keyboards, understanding-matrix, understanding-qmk, conduct"
   }];
 
 // Construct plaintext help menu fallback


### PR DESCRIPTION
Misleading `help` description.  Fixed to agree with the command.